### PR TITLE
Fix failure to transfer if file name contains spaces

### DIFF
--- a/Boop/Form1.cs
+++ b/Boop/Form1.cs
@@ -1,15 +1,10 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
 using System.Diagnostics;
-using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Sockets;
 using System.Text;
-using System.Threading.Tasks;
 using System.Windows.Forms;
 
 namespace Boop
@@ -105,7 +100,7 @@ namespace Boop
         {
             if (ValidateIPv4(txt3DS.Text) == false)
             {
-                MessageBox.Show("That doesn't look like an IP adress." + Environment.NewLine + "An IP adress looks something like this: 192.168.1.6" + Environment.NewLine + "(That is: Numbers DOT numbers DOT numbers DOT numbers)", "Error on the IP adress", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show("That doesn't look like an IP address." + Environment.NewLine + "An IP address looks something like this: 192.168.1.6" + Environment.NewLine + "(That is: Numbers DOT numbers DOT numbers DOT numbers)", "Error on the IP address", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 //reenable controls?
 
                 return;
@@ -155,7 +150,7 @@ namespace Boop
             String message = "";
             foreach (var CIA in FilesToBoop)
             {
-               message += LocalIP() + ":8080/" + Path.GetFileName(CIA) + "\n";
+               message += LocalIP() + ":8080/" + Uri.EscapeUriString(Path.GetFileName(CIA)) + "\n";
             }
 
             //boop the info to the 3ds...

--- a/Boop/SimpleHTTPServer.cs
+++ b/Boop/SimpleHTTPServer.cs
@@ -162,8 +162,7 @@ namespace Boop
         {
             string filename = context.Request.Url.AbsolutePath;
             Console.WriteLine(filename);
-            filename = filename.Substring(1);
-            filename = filename.Replace("%20", " ");
+            filename = filename.Substring(1).Replace("%20", " ");
 
             if (string.IsNullOrEmpty(filename))
             {

--- a/Boop/SimpleHTTPServer.cs
+++ b/Boop/SimpleHTTPServer.cs
@@ -163,6 +163,7 @@ namespace Boop
             string filename = context.Request.Url.AbsolutePath;
             Console.WriteLine(filename);
             filename = filename.Substring(1);
+            filename = filename.Replace("%20", " ");
 
             if (string.IsNullOrEmpty(filename))
             {


### PR DESCRIPTION
fixes #5
-first escape the spaces in filename with `Uri.EscapeUriString` to prevent FBI from complaining
-then revert the escaped spaces (%20) in `SimpleHTTPServer` so it can actually find the file in the file system

there might be a better way to do it but this works for now